### PR TITLE
feat: creación de la entidad usuario

### DIFF
--- a/src/main/java/com/salesianostriana/dam/campusswap/entidades/Usuario.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/entidades/Usuario.java
@@ -1,0 +1,34 @@
+package com.salesianostriana.dam.campusswap.entidades;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.*;
+import org.springframework.expression.spel.ast.BooleanLiteral;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@Entity
+public class Usuario {
+
+    @Id
+    @GeneratedValue
+    private UUID id;
+
+    private String nombre;
+    private String email;
+    private String constrasena;
+    private String fotoPerfil;
+    private String descripcion;
+    private double reputacionMedia;
+    private LocalDateTime fechaRegistro;
+    private Boolean activo;
+
+}


### PR DESCRIPTION
This pull request introduces a new JPA entity class for users in the application. The new `Usuario` class models user data, includes relevant fields, and utilizes Lombok annotations to reduce boilerplate code.

**New Entity Definition:**

* Added a new `Usuario` entity class with fields for `id`, `nombre`, `email`, `constrasena`, `fotoPerfil`, `descripcion`, `reputacionMedia`, `fechaRegistro`, and `activo`. The class uses Lombok annotations for constructors, getters, setters, builder pattern, and `toString` method, and is annotated with `@Entity` for JPA persistence. (`src/main/java/com/salesianostriana/dam/campusswap/entidades/Usuario.java`)