### PR TITLE
feat: relaciones onetomany con anuncio, valoración y favorito. 

### DIFF
--- a/src/main/java/com/salesianostriana/dam/campusswap/entidades/Usuario.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/entidades/Usuario.java
@@ -38,10 +38,15 @@ public class Usuario {
     @OneToMany(mappedBy = "usuario", orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Anuncio> anuncios = new ArrayList<>();
 
-    @OneToMany(mappedBy = "usuario", orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<Valoracion> valoraciones = new ArrayList<>();
+    @OneToMany(mappedBy = "evaluador", orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Valoracion> valoracionesEnviadas = new ArrayList<>();
+
+    @OneToMany(mappedBy = "evaluado", orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Valoracion> valoracionesRecibidas = new ArrayList<>();
 
     @OneToMany(mappedBy = "usuario", orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Favorito> favoritos = new ArrayList<>();
+
+
 
 }


### PR DESCRIPTION
This pull request adds new entity relationships to the `Usuario` class to better represent its associations with other domain entities. The main focus is on establishing one-to-many relationships for `Anuncio`, `Valoracion`, and `Favorito` entities.

**Entity Relationship Enhancements:**

* Added a one-to-many relationship between `Usuario` and `Anuncio` via the `anuncios` field, enabling each user to have multiple associated ads.
* Introduced one-to-many relationships for `Usuario` to `Valoracion` through `valoracionesEnviadas` (as evaluator) and `valoracionesRecibidas` (as evaluated), allowing tracking of sent and received ratings per user.
* Added a one-to-many relationship between `Usuario` and `Favorito` via the `favoritos` field, enabling users to have multiple favorites.

**Imports and Initialization:**

* Updated import statements and initialized new lists in the `Usuario` class to support the above relationships.