### PR TITLE
F01.2

### DIFF
--- a/src/main/java/com/salesianostriana/dam/campusswap/entidades/Categoria.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/entidades/Categoria.java
@@ -10,9 +10,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
-
-
-
 @Entity
 @Getter @Setter
 @NoArgsConstructor @AllArgsConstructor


### PR DESCRIPTION
This pull request simplifies the `Categoria` entity by removing custom implementations of the `equals` and `hashCode` methods, as well as unnecessary imports. These changes help streamline the code and reduce potential issues related to entity comparison.

Code cleanup and simplification:

* Removed the custom `equals` and `hashCode` methods from the `Categoria` class, which previously handled Hibernate proxy comparisons.
* Removed unused imports, including `org.hibernate.proxy.HibernateProxy` and `java.util.Objects`, from `Categoria.java`.