### PR TITLE
RF01.3

### DIFF
--- a/src/main/java/com/salesianostriana/dam/campusswap/entidades/Usuario.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/entidades/Usuario.java
@@ -39,26 +39,6 @@ public class Usuario {
     @OneToMany(mappedBy = "usuario", orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Anuncio> anuncios = new ArrayList<>();
 
-    @Builder.Default
-    @OneToMany(mappedBy = "evaluador", orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<Valoracion> valoracionesEnviadas = new ArrayList<>();
-
-    @Builder.Default
-    @OneToMany(mappedBy = "evaluado", orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<Valoracion> valoracionesRecibidas = new ArrayList<>();
-
-    @Builder.Default
-    @OneToMany(mappedBy = "usuario", orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<Favorito> favoritos = new ArrayList<>();
-
-    @Builder.Default
-    @OneToMany(mappedBy = "emisor", orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<Mensaje> mensajesEnviados = new ArrayList<>();
-
-    @Builder.Default
-    @OneToMany(mappedBy = "receptor", orphanRemoval = true, fetch = FetchType.LAZY)
-    private List<Mensaje> mensajesRecibidos = new ArrayList<>();
-
     public void agregarAnuncio(Anuncio anuncio) {
         anuncios.add(anuncio);
         anuncio.setUsuario(this);


### PR DESCRIPTION
This pull request simplifies the `Usuario` entity by removing several relationship fields that are no longer needed. The main focus is on cleaning up the model to reduce complexity and potential maintenance overhead.

Entity relationship cleanup:

* Removed the `valoracionesEnviadas` and `valoracionesRecibidas` fields, which represented sent and received ratings, along with their associated JPA mappings.
* Removed the `favoritos` field, which managed the user's favorites, and its JPA mapping.
* Removed the `mensajesEnviados` and `mensajesRecibidos` fields, which tracked sent and received messages, including their JPA mappings.