### PR TITLE
fix: cambiar relación a unidireccional

### DIFF
--- a/src/main/java/com/salesianostriana/dam/campusswap/entidades/Anuncio.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/entidades/Anuncio.java
@@ -48,9 +48,6 @@ public class Anuncio {
     private Valoracion valoracion;
 
 
-    @OneToMany(mappedBy = "anuncio",orphanRemoval = true,fetch = FetchType.LAZY)
-    @Builder.Default
-    private List<Mensaje> mensajes = new ArrayList<>();
 
     public Anuncio modificar(Anuncio anuncio) {
         this.titulo = anuncio.getTitulo();


### PR DESCRIPTION
This pull request makes a small change to the `Anuncio` entity by removing its relationship with the `Mensaje` entity. The `mensajes` field and its associated JPA annotations have been deleted from the class.