### PR TITLE
feat: implementación de mi parte de ficheros

### DIFF
--- a/src/main/java/com/salesianostriana/dam/campusswap/ficheros/general/model/AbstractFileMetadata.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/ficheros/general/model/AbstractFileMetadata.java
@@ -1,0 +1,22 @@
+package com.salesianostriana.dam.campusswap.ficheros.general.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public abstract class AbstractFileMetadata implements FileMetadata {
+
+    protected String id;
+    protected String filename;
+    protected String URL;
+    protected String deleteId;
+    protected String deleteURL;
+
+}

--- a/src/main/java/com/salesianostriana/dam/campusswap/ficheros/general/utiles/MimeTypeDetector.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/ficheros/general/utiles/MimeTypeDetector.java
@@ -1,0 +1,10 @@
+package com.salesianostriana.dam.campusswap.ficheros.general.utiles;
+
+import org.springframework.core.io.Resource;
+
+
+public interface MimeTypeDetector {
+
+    String getMimeType(Resource resource);
+
+}

--- a/src/main/java/com/salesianostriana/dam/campusswap/ficheros/logica/StorageService.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/ficheros/logica/StorageService.java
@@ -1,0 +1,17 @@
+package com.salesianostriana.dam.campusswap.ficheros.logica;
+
+import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StorageService {
+
+    void init();
+
+    FileMetadata store(MultipartFile file);
+
+    Resource loadAsResource(String id);
+
+    void deleteFile(String filename);
+
+
+}


### PR DESCRIPTION
This pull request introduces foundational abstractions for file handling in the project. It adds interfaces and an abstract class to standardize file metadata, storage operations, and MIME type detection. These changes lay the groundwork for consistent and extensible file management across the application.

**File metadata and storage abstractions:**

* Added `AbstractFileMetadata` abstract class implementing `FileMetadata`, providing common fields like `id`, `filename`, `URL`, `deleteId`, and `deleteURL` to be shared by all file metadata implementations.
* Introduced `StorageService` interface defining core file storage operations such as initialization, storing files, loading resources, and deleting files.

**File utility abstraction:**

* Added `MimeTypeDetector` interface to standardize the detection of MIME types for resources.