### PR TITLE
feat: implementación de ficheros

### DIFF
--- a/src/main/java/com/salesianostriana/dam/campusswap/ficheros/general/model/FileMetadata.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/ficheros/general/model/FileMetadata.java
@@ -1,0 +1,17 @@
+package com.salesianostriana.dam.campusswap.ficheros.general.model;
+
+public interface FileMetadata {
+
+    String getFilename();
+    String getURL();
+    String getDeleteId();
+    String getDeleteURL();
+    String getId();
+    void setFilename(String filename);
+    void setURL(String url);
+    void setDeleteId(String deleteId);
+    void setDeleteURL(String deleteURL);
+    void setId(String id);
+
+
+}

--- a/src/main/java/com/salesianostriana/dam/campusswap/ficheros/logica/local/FileSystemStorageService.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/ficheros/logica/local/FileSystemStorageService.java
@@ -1,0 +1,132 @@
+package com.salesianostriana.dam.campusswap.ficheros.logica.local;
+
+import com.example.demo.ficheros.general.excepciones.StorageException;
+import com.example.demo.ficheros.general.model.FileMetadata;
+import com.example.demo.ficheros.logica.StorageService;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.FileSystemUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+//@Primary
+@Service
+//@ConditionalOnProperty(name = "storage.type", havingValue = "local", matchIfMissing = true)
+public class FileSystemStorageService implements StorageService {
+
+    @Value("${storage.location}")
+    private String storageLocation;
+
+    private Path rootLocation;
+
+
+    @PostConstruct
+    @Override
+    public void init() {
+        rootLocation = Paths.get(storageLocation);
+        try {
+            Files.createDirectories(rootLocation);
+        } catch (IOException e) {
+            throw new StorageException("Could not initialize storage location", e);
+        }
+
+    }
+
+    @Override
+    public FileMetadata store(MultipartFile file)  {
+        try {
+            String filename =  store(file.getBytes(), file.getOriginalFilename(), file.getContentType());
+            return LocalFileMetadataImpl.of(filename);
+        } catch (Exception ex) {
+            throw new StorageException("Error storing file: " + file.getOriginalFilename(), ex);
+        }
+    }
+    @Override
+    public Resource loadAsResource(String id) {
+        try {
+            Path file = load(id);
+            UrlResource resource =
+                    new UrlResource(file.toUri());
+
+            if (resource.exists() && resource.isReadable()) {
+                return resource;
+            } else {
+                throw new StorageException("Could not read file: " + id);
+            }
+
+        } catch (MalformedURLException ex) {
+            throw new StorageException("Could not read file: " + id);
+        }
+    }
+
+    @Override
+    public void deleteFile(String filename) {
+        try {
+            Files.delete(load(filename));
+        } catch (IOException e) {
+            throw new StorageException("Could not delete file:" + filename);
+        }
+    }
+
+    private String store(byte[] file, String filename, String contentType) throws Exception {
+
+        // Limpiamos el nombre del fichero
+        String newFilename = StringUtils.cleanPath(filename);
+
+        if (file.length == 0)
+            throw new StorageException("The file is empty");
+
+        newFilename = calculateNewFilename(newFilename);
+
+        try (InputStream inputStream = new ByteArrayInputStream(file)) {
+            Files.copy(inputStream, rootLocation.resolve(newFilename),
+                    StandardCopyOption.REPLACE_EXISTING
+                    );
+        } catch(IOException ex) {
+            throw new StorageException("Error storing file: " + newFilename, ex);
+        }
+
+        return newFilename;
+    }
+
+    private String calculateNewFilename(String filename) {
+        String newFilename = filename;
+
+        while(Files.exists(rootLocation.resolve(newFilename))) {
+            // Tratamos de generar un nuevo
+            String extension = StringUtils.getFilenameExtension(newFilename);
+            String name = newFilename.replace("." + extension, "");
+
+            String suffix = Long.toString(System.currentTimeMillis());
+            suffix = suffix.substring(suffix.length()-6);
+
+            newFilename = name + "_" + suffix + "." + extension;
+
+        }
+        return newFilename;
+    }
+
+    private Path load(String filename) {
+        return rootLocation.resolve(filename);
+    }
+
+    public void deleteAll() {
+        try {
+            FileSystemUtils.deleteRecursively(rootLocation);
+        } catch (IOException e) {
+            throw new StorageException("Could not delete all");
+        }
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -9,3 +9,9 @@ spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.h2.console.enabled=true
 spring.jpa.show-sql=true
+storage.location=./uploads
+
+# Max attachment size
+spring.servlet.multipart.max-file-size=5MB
+# Max request size
+spring.servlet.multipart.max-request-size=10MB


### PR DESCRIPTION
This pull request introduces a local file storage implementation for handling file uploads and management in the project. It adds a new service for storing files on the local filesystem, defines a metadata interface for file information, and updates configuration to support file storage and size limits.

File storage logic:

* Added `FileSystemStorageService` in `src/main/java/com/salesianostriana/dam/campusswap/ficheros/logica/local/FileSystemStorageService.java` to handle file saving, loading, and deletion using the local filesystem. This service includes filename sanitization, duplicate handling, and error management.

File metadata abstraction:

* Introduced the `FileMetadata` interface in `src/main/java/com/salesianostriana/dam/campusswap/ficheros/general/model/FileMetadata.java` to standardize file metadata access and manipulation.

Configuration updates:

* Updated `application-dev.properties` to specify the storage location (`storage.location=./uploads`) and set maximum file and request sizes for uploads.