### PR TITLE
feat: actualizar foto de perfil del usuario

### DIFF
--- a/src/main/java/com/salesianostriana/dam/campusswap/ficheros/logica/StorageService.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/ficheros/logica/StorageService.java
@@ -1,5 +1,6 @@
 package com.salesianostriana.dam.campusswap.ficheros.logica;
 
+import com.salesianostriana.dam.campusswap.ficheros.general.model.FileMetadata;
 import org.springframework.core.io.Resource;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/com/salesianostriana/dam/campusswap/ficheros/logica/local/FileSystemStorageService.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/ficheros/logica/local/FileSystemStorageService.java
@@ -1,8 +1,8 @@
 package com.salesianostriana.dam.campusswap.ficheros.logica.local;
 
-import com.example.demo.ficheros.general.excepciones.StorageException;
-import com.example.demo.ficheros.general.model.FileMetadata;
-import com.example.demo.ficheros.logica.StorageService;
+import com.salesianostriana.dam.campusswap.ficheros.general.excepciones.StorageException;
+import com.salesianostriana.dam.campusswap.ficheros.general.model.FileMetadata;
+import com.salesianostriana.dam.campusswap.ficheros.logica.StorageService;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;

--- a/src/main/java/com/salesianostriana/dam/campusswap/ficheros/logica/local/LocalFileMetadataImpl.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/ficheros/logica/local/LocalFileMetadataImpl.java
@@ -1,5 +1,7 @@
 package com.salesianostriana.dam.campusswap.ficheros.logica.local;
 
+import com.salesianostriana.dam.campusswap.ficheros.general.model.AbstractFileMetadata;
+import com.salesianostriana.dam.campusswap.ficheros.general.model.FileMetadata;
 import lombok.experimental.SuperBuilder;
 
 

--- a/src/main/java/com/salesianostriana/dam/campusswap/servicios/funciones/ServicioUsuario.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/servicios/funciones/ServicioUsuario.java
@@ -1,0 +1,38 @@
+package com.salesianostriana.dam.campusswap.servicios.funciones;
+
+import com.salesianostriana.dam.campusswap.entidades.Usuario;
+import com.salesianostriana.dam.campusswap.ficheros.general.model.FileMetadata;
+import com.salesianostriana.dam.campusswap.ficheros.logica.StorageService;
+import com.salesianostriana.dam.campusswap.servicios.base.ServicioBaseUsuario;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+
+@Service
+@RequiredArgsConstructor
+public class ServicioUsuario {
+
+    private final ServicioBaseUsuario servicioBaseUsuario;
+    private final StorageService storageService;
+
+
+
+    public Usuario actualizarFotoPerfil(Usuario usuarioAutenticado, MultipartFile file) {
+
+        Usuario usuario = servicioBaseUsuario.buscarPorId(usuarioAutenticado.getId());
+
+        if(usuario.getFotoPerfil() !=null){
+            storageService.deleteFile(usuario.getFotoPerfil());
+        }
+
+        FileMetadata fileMetadata = storageService.store(file);
+
+        usuario.setFotoPerfil(fileMetadata.getFilename());
+
+        return servicioBaseUsuario.guardar(usuario);
+
+    }
+
+
+}


### PR DESCRIPTION
This pull request primarily introduces a new service for handling user profile photo updates and standardizes import paths in several files to use the correct package structure. The most significant change is the addition of the `ServicioUsuario` class, which encapsulates the logic for updating a user's profile picture, including deleting the old photo and storing the new one.

**New functionality:**

* Added `ServicioUsuario` service with a method `actualizarFotoPerfil` to handle updating a user's profile photo, including deleting the old file and saving the new one.

**Codebase consistency and import fixes:**

* Updated import statements in `StorageService.java`, `FileSystemStorageService.java`, and `LocalFileMetadataImpl.java` to use the correct `com.salesianostriana.dam.campusswap` package structure for file metadata and storage exceptions. [[1]](diffhunk://#diff-f1659932d30a057adcdb1abce75425a4f543a97af5122aaae2a77d70d895a67eR3) [[2]](diffhunk://#diff-99f263103c7eb788d3b84ddd75797d9e73f979f92b3865e91daced5cb579c268L3-R5) [[3]](diffhunk://#diff-eb29a8d2c192b634be197e15ee7973faf1847de4382b1683b7d7172484b7b031R3-R4)