### PR TITLE
feat: controler para crear un endpoint por el que obtener las categoria

### DIFF
--- a/src/main/java/com/salesianostriana/dam/campusswap/controladores/ControladorCategoria.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/controladores/ControladorCategoria.java
@@ -1,0 +1,148 @@
+package com.salesianostriana.dam.campusswap.controladores;
+
+import com.salesianostriana.dam.campusswap.entidades.extras.dtos.categoria.CategoriaResponseDto;
+import com.salesianostriana.dam.campusswap.servicios.funciones.ServicioCategoria;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/categorias")
+@RequiredArgsConstructor
+@Tag(
+        name = "Controlador de Categorías",
+        description = "Endpoints relacionados con la gestión de categorías de anuncios."
+)
+public class ControladorCategoria {
+
+    private final ServicioCategoria servicioCategoria;
+
+    @GetMapping
+    @Operation(
+            summary = "Obtener todas las categorías",
+            description = "Endpoint para obtener el listado completo de categorías disponibles en la plataforma. " +
+                    "Este endpoint está disponible para usuarios autenticados."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Categorías obtenidas correctamente",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = CategoriaResponseDto.class),
+                    examples = {
+                            @ExampleObject(
+                                    value = """
+                                            [
+                                                {
+                                                    "id": 1,
+                                                    "nombre": "Electrónica e Informática"
+                                                },
+                                                {
+                                                    "id": 2,
+                                                    "nombre": "Libros y Material Académico"
+                                                },
+                                                {
+                                                    "id": 3,
+                                                    "nombre": "Ropa y Accesorios"
+                                                },
+                                                {
+                                                    "id": 4,
+                                                    "nombre": "Deportes y Ocio"
+                                                },
+                                                {
+                                                    "id": 5,
+                                                    "nombre": "Hogar y Decoración"
+                                                },
+                                                {
+                                                    "id": 6,
+                                                    "nombre": "Música y Entretenimiento"
+                                                },
+                                                {
+                                                    "id": 7,
+                                                    "nombre": "Vehículos y Transporte"
+                                                },
+                                                {
+                                                    "id": 8,
+                                                    "nombre": "Otros"
+                                                }
+                                            ]
+                                            """
+                            )
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "401",
+            description = "No autorizado. Se requiere autenticación para acceder a este recurso.",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ProblemDetail.class),
+                    examples = {
+                            @ExampleObject(
+                                    value = """
+                                            {
+                                                "detail": "Acceso denegado. No se ha proporcionado un token de autenticación válido.",
+                                                "instance": "/api/v1/catalogo",
+                                                "status": 401,
+                                                "title": "No autorizado."
+                                            }
+                                            """
+                            )
+                    })
+    )
+    @ApiResponse(
+            responseCode = "403",
+            description = "Solicitud prohibida",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ProblemDetail.class),
+                    examples = {
+                            @ExampleObject(
+                                    value = """
+                                            {
+                                                "detail": "No se puede reportar un anuncio que te pertenece",
+                                                "instance": "/api/v1/anuncios/2",
+                                                "status": 403,
+                                                "title": "Recurso perteneciente al usuario"
+                                            }
+                                            """
+                            )
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "500",
+            description = "Error interno del servidor",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ProblemDetail.class),
+                    examples = {
+                            @ExampleObject(
+                                    value = """
+                                            {
+                                                "detail": "Ha ocurrido un error inesperado",
+                                                "instance": "/api/v1/catalogo",
+                                                "status": 500,
+                                                "title": "Error inesperado."
+                                            }
+                                            """
+                            )
+                    }
+            )
+    )
+    @PreAuthorize("hasAnyRole('ADMIN', 'USUARIO')")
+    public ResponseEntity<List<CategoriaResponseDto>> obtenerTodas() {
+        return ResponseEntity.ok(servicioCategoria.obtenerTodas().stream().map(CategoriaResponseDto::of).toList());
+    }
+}

--- a/src/main/java/com/salesianostriana/dam/campusswap/entidades/extras/dtos/categoria/CategoriaResponseDto.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/entidades/extras/dtos/categoria/CategoriaResponseDto.java
@@ -1,0 +1,12 @@
+package com.salesianostriana.dam.campusswap.entidades.extras.dtos.categoria;
+
+import com.salesianostriana.dam.campusswap.entidades.Categoria;
+
+public record CategoriaResponseDto(
+        Long id,
+        String nombre
+) {
+    public static CategoriaResponseDto of(Categoria c) {
+        return new CategoriaResponseDto(c.getId(), c.getNombre());
+    }
+}

--- a/src/main/java/com/salesianostriana/dam/campusswap/servicios/funciones/ServicioCategoria.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/servicios/funciones/ServicioCategoria.java
@@ -1,0 +1,21 @@
+package com.salesianostriana.dam.campusswap.servicios.funciones;
+
+import com.salesianostriana.dam.campusswap.entidades.Categoria;
+import com.salesianostriana.dam.campusswap.entidades.extras.dtos.categoria.CategoriaResponseDto;
+import com.salesianostriana.dam.campusswap.repositorios.RepositorioCategoria;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ServicioCategoria {
+
+    private final RepositorioCategoria repositorioCategoria;
+
+    public List<Categoria> obtenerTodas(){
+        return repositorioCategoria.findAll();
+    }
+}


### PR DESCRIPTION
This pull request introduces a new endpoint for retrieving all available categories in the application. It adds a new controller, service, and response DTO to support this functionality, as well as comprehensive API documentation and security annotations.

**New Category Retrieval Feature:**

* Added `ControladorCategoria` class to expose a `/api/v1/categorias` endpoint for authenticated users to fetch all categories, with detailed OpenAPI documentation and security via `@PreAuthorize`.
* Implemented `ServicioCategoria` service to encapsulate the logic for fetching all categories from the database using `RepositorioCategoria`.
* Introduced `CategoriaResponseDto` record to provide a clean and simple structure for category data in API responses, including a static factory method for mapping from the `Categoria` entity.…ias almacenadas