### PR TITLE
fix: mensajes by kuroo

### DIFF
--- a/src/main/java/com/salesianostriana/dam/campusswap/controladores/ControladorMensaje.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/controladores/ControladorMensaje.java
@@ -3,7 +3,7 @@ package com.salesianostriana.dam.campusswap.controladores;
 import com.salesianostriana.dam.campusswap.entidades.Mensaje;
 import com.salesianostriana.dam.campusswap.entidades.Usuario;
 import com.salesianostriana.dam.campusswap.entidades.extras.dtos.mensaje.EnviarMensajeRequestDto;
-import com.salesianostriana.dam.campusswap.entidades.extras.dtos.mensaje.ListarChatResponseDto;
+import com.salesianostriana.dam.campusswap.entidades.extras.dtos.mensaje.chat.ListarChatResponseDto;
 import com.salesianostriana.dam.campusswap.entidades.extras.dtos.mensaje.MensajeResponseDto;
 import com.salesianostriana.dam.campusswap.entidades.extras.dtos.mensaje.ListarMensajeResponseDto;
 import com.salesianostriana.dam.campusswap.servicios.funciones.ServicioMensaje;
@@ -27,7 +27,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Set;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/salesianostriana/dam/campusswap/entidades/extras/dtos/mensaje/chat/AnuncioChatDto.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/entidades/extras/dtos/mensaje/chat/AnuncioChatDto.java
@@ -1,0 +1,15 @@
+package com.salesianostriana.dam.campusswap.entidades.extras.dtos.mensaje.chat;
+
+import com.salesianostriana.dam.campusswap.entidades.Anuncio;
+
+public record AnuncioChatDto(
+        Long id,
+        String titulo,
+        String imagen
+) {
+
+    public static AnuncioChatDto of(Anuncio a) {
+        return new AnuncioChatDto(a.getId(), a.getTitulo(), a.getImagen());
+    }
+
+}

--- a/src/main/java/com/salesianostriana/dam/campusswap/entidades/extras/dtos/mensaje/chat/ListarChatResponseDto.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/entidades/extras/dtos/mensaje/chat/ListarChatResponseDto.java
@@ -1,17 +1,18 @@
-package com.salesianostriana.dam.campusswap.entidades.extras.dtos.mensaje;
+package com.salesianostriana.dam.campusswap.entidades.extras.dtos.mensaje.chat;
 
 import com.salesianostriana.dam.campusswap.entidades.Mensaje;
+import com.salesianostriana.dam.campusswap.entidades.extras.dtos.mensaje.MensajeResponseDto;
 
 import java.util.Set;
 
 public record ListarChatResponseDto(
-        Long idAnuncio,
-        Set<String> participantes,
+        AnuncioChatDto anuncio,
+        Set<UsuarioChatDto> participantes,
         MensajeResponseDto ultimoMensaje
 ) {
     public static ListarChatResponseDto lastMensaje(ListarChatResponseDto chat, Mensaje ultimoMensaje) {
         return new ListarChatResponseDto(
-                chat.idAnuncio(),
+                chat.anuncio(),
                 chat.participantes(),
                 MensajeResponseDto.of(ultimoMensaje)
         );

--- a/src/main/java/com/salesianostriana/dam/campusswap/entidades/extras/dtos/mensaje/chat/UsuarioChatDto.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/entidades/extras/dtos/mensaje/chat/UsuarioChatDto.java
@@ -1,0 +1,15 @@
+package com.salesianostriana.dam.campusswap.entidades.extras.dtos.mensaje.chat;
+
+import com.salesianostriana.dam.campusswap.entidades.Usuario;
+
+public record UsuarioChatDto(
+        String id,
+        String nombre,
+        boolean yo
+) {
+
+    public static UsuarioChatDto of(Usuario usuario, boolean esYo) {
+        return new UsuarioChatDto(usuario.getId().toString(), usuario.getNombre(), esYo);
+    }
+
+}


### PR DESCRIPTION
This pull request refactors how chat-related DTOs are structured and used in the messaging functionality. The main focus is on improving type safety and clarity by introducing specific DTOs for chat participants and associated ads, and reorganizing related classes into a dedicated package. The changes also update service logic to use these new DTOs, leading to cleaner and more maintainable code.

**DTO Structure Refactoring:**

* Introduced new DTOs: `AnuncioChatDto` for representing ad information and `UsuarioChatDto` for representing chat participants, both located in the new `mensaje.chat` package. [[1]](diffhunk://#diff-56f0ccd1cd45d6fb07e653783f9562e7b1c704c7570b8f83f2204fb57be40d07R1-R15) [[2]](diffhunk://#diff-4064c381d39f9b242ff8a9b093310b81b4aa6cfde60c400d034cdf1a83a10012R1-R15)
* Refactored `ListarChatResponseDto` to use `AnuncioChatDto` and a set of `UsuarioChatDto` instead of primitive types, improving type safety and expressiveness.

**Code Organization and Imports:**

* Moved `ListarChatResponseDto` to the `mensaje.chat` package, and updated all relevant import statements to reflect this new location. [[1]](diffhunk://#diff-69e3068777378a111903cedd730c628772ebeb877064b637fd693e995d2bd84bL6-R6) [[2]](diffhunk://#diff-5078bf444123ee997521bf60856f3b889e649e89b53e5fea681ad3cb8bcf1169L1-R15)

**Service Logic Updates:**

* Updated `ServicioMensaje` methods to construct and use the new DTOs, including building participant sets with `UsuarioChatDto` and using `AnuncioChatDto` for ad information in chat responses.
* Adjusted chat lookup and comparison logic to work with the new DTO structure, ensuring correct identification of chats and participants. [[1]](diffhunk://#diff-2df1005da44ad69ab5674a77bed2636fbc81cfa1a90277784104c31a3d0716e9L83-R84) [[2]](diffhunk://#diff-2df1005da44ad69ab5674a77bed2636fbc81cfa1a90277784104c31a3d0716e9L95-R96) [[3]](diffhunk://#diff-2df1005da44ad69ab5674a77bed2636fbc81cfa1a90277784104c31a3d0716e9L105-R108)