### PR TITLE
feat: función para realizar un reescalado de imagen

### DIFF
--- a/src/main/java/com/salesianostriana/dam/campusswap/ficheros/logica/local/FileSystemStorageService.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/ficheros/logica/local/FileSystemStorageService.java
@@ -12,6 +12,9 @@ import org.springframework.util.FileSystemUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -67,6 +70,27 @@ public class FileSystemStorageService implements StorageService {
         } catch (MalformedURLException ex) {
             throw new StorageException("Could not read file: " + id);
         }
+    }
+
+    private void redimensionarImagen(BufferedImage originalImage, int targetWidth, int targetHeight, Path targetPath, String format) throws IOException {
+        int finalWidth = targetWidth;
+        int finalHeight = targetHeight;
+
+        if(targetHeight == -1){
+            double ratio = (double) targetWidth / originalImage.getWidth();
+            finalHeight = (int) (originalImage.getHeight() * ratio);
+        }
+
+        int type = (originalImage.getTransparency() == Transparency.OPAQUE) ? BufferedImage.TYPE_INT_RGB : BufferedImage.TYPE_INT_ARGB;
+
+        BufferedImage resizedImage = new BufferedImage(finalWidth, finalHeight, type);
+        Graphics2D g = resizedImage.createGraphics();
+
+        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        g.drawImage(originalImage, 0, 0, finalWidth, finalHeight, null);
+        g.dispose();
+
+        ImageIO.write(resizedImage, format != null ? format : "jpg", targetPath.toFile());
     }
 
     @Override


### PR DESCRIPTION
This pull request adds image resizing functionality to the `FileSystemStorageService` class, allowing images to be resized before being saved to disk. The changes include importing necessary image processing libraries and implementing a private method for resizing images.

**Image processing enhancements:**

* Added imports for `ImageIO`, `BufferedImage`, and `Graphics2D` to support image manipulation within `FileSystemStorageService.java`.
* Implemented a new private method `redimensionarImagen` that resizes a given `BufferedImage` to a specified width and height, preserving aspect ratio if the height is set to -1, and saves the result to a specified path in the desired format.