### PR TITLE
fix: añadir precio anuncio

### DIFF
--- a/src/main/java/com/salesianostriana/dam/campusswap/entidades/extras/dtos/mensaje/chat/AnuncioChatDto.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/entidades/extras/dtos/mensaje/chat/AnuncioChatDto.java
@@ -5,11 +5,12 @@ import com.salesianostriana.dam.campusswap.entidades.Anuncio;
 public record AnuncioChatDto(
         Long id,
         String titulo,
-        String imagen
+        String imagen,
+        Double precio
 ) {
 
     public static AnuncioChatDto of(Anuncio a) {
-        return new AnuncioChatDto(a.getId(), a.getTitulo(), a.getImagen());
+        return new AnuncioChatDto(a.getId(), a.getTitulo(), a.getImagen(),a.getPrecio());
     }
 
 }


### PR DESCRIPTION
This pull request makes a small update to the `AnuncioChatDto` record by adding a new `precio` (price) field. This allows the DTO to carry price information along with the existing fields, and updates the static factory method to include this new field.

* Added a `Double precio` field to the `AnuncioChatDto` record and updated the `of` method to populate it from the `Anuncio` entity.