### PR TITLE
fix: la anterior llamada nunca guardaba la foto nueva

### DIFF
--- a/src/main/java/com/salesianostriana/dam/campusswap/servicios/funciones/ServicioAnuncio.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/servicios/funciones/ServicioAnuncio.java
@@ -72,7 +72,7 @@ public class ServicioAnuncio {
             original.setImagen(imagenAntigua);
         }
 
-        return servicioBaseAnuncio.guardar(original.modificar(anuncio));
+        return servicioBaseAnuncio.guardar(original);
     }
 
     public Page<Anuncio> obtenerAnuncios(Pageable pageable, String idUsuario) {


### PR DESCRIPTION
This pull request makes a small but important change to the `editarAnuncio` method in `ServicioAnuncio.java`. The change ensures that the modified `Anuncio` object is saved directly, rather than applying the `modificar` method before saving. This simplifies the update logic and may prevent unintended modifications.

* Changed `editarAnuncio` to save the `original` `Anuncio` object directly, instead of saving the result of `original.modificar(anuncio)`.