### PR TITLE
F17.2

### DIFF
--- a/src/main/java/com/salesianostriana/dam/campusswap/seguridad/auth/AuthController.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/seguridad/auth/AuthController.java
@@ -82,11 +82,21 @@ public class AuthController {
                                     name = "Ejemplo de respuesta de solicitud inválida",
                                     value = """
                             {
-                                "timestamp": "2024-06-01T12:00:00.000+00:00",
+                                "type": "about:blank",
+                                "title": "Bad Request",
                                 "status": 400,
-                                "error": "Bad Request",
-                                "message": "El campo 'email' es obligatorio.",
-                                "path": "/auth/login"
+                                "detail": "Error de validación en el cuerpo de la petición.",
+                                "instance": "/auth/login",
+                                "invalid-params": [
+                                    {
+                                        "name": "email",
+                                        "reason": "must not be blank"
+                                    },
+                                    {
+                                        "name": "password",
+                                        "reason": "size must be between 8 and 64"
+                                    }
+                                ]
                             }
                             """
                             )


### PR DESCRIPTION
This pull request enhances the `AuthController` by adding detailed OpenAPI/Swagger documentation for the authentication endpoints and improves the clarity of HTTP response handling. The main focus is to make the API more self-descriptive for consumers and to ensure response codes are handled correctly.

Documentation improvements:

* Added `@Tag`, `@Operation`, and `@ApiResponses` annotations to `AuthController`, `doLogin`, and `doRegister` methods, providing clear descriptions, expected responses, and example payloads for the authentication endpoints. [[1]](diffhunk://#diff-c8d6dad93b09becb72be647d0a459c24a6cf1b1639a4c04630dac96b6d1bee0dR7-R16) [[2]](diffhunk://#diff-c8d6dad93b09becb72be647d0a459c24a6cf1b1639a4c04630dac96b6d1bee0dR26-R198)

HTTP response handling:

* Updated the `doLogin` method to use `ResponseEntity.ok()` for successful logins, ensuring the response code is correctly set to 200 instead of 201.
* Updated the `doRegister` method to use `ResponseEntity.status(HttpStatus.CREATED)` for successful registrations, explicitly setting the response code to 201.…el ok