### PR TITLE
F17.5

### DIFF
--- a/src/main/java/com/salesianostriana/dam/campusswap/seguridad/SecurityConfig.java
+++ b/src/main/java/com/salesianostriana/dam/campusswap/seguridad/SecurityConfig.java
@@ -84,7 +84,9 @@ public class SecurityConfig {
                 .requestMatchers("/api/v1/imagen/**").permitAll()
                 .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/**").hasAnyRole("USUARIO", "ADMIN")
+
                 .requestMatchers("/auth/**").permitAll()
+                .requestMatchers("/swagger-ui/**","/v3/api-docs/**").permitAll()
                 .requestMatchers("/h2-console/**").permitAll()
                 .anyRequest().authenticated()
         );

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=campusswap
 
 # quitar comentario para ejecutar sin docker
-spring.profiles.active=prod
+spring.profiles.active=dev
 
 spring.servlet.multipart.max-file-size=5MB
 spring.servlet.multipart.max-request-size=10MB


### PR DESCRIPTION
This pull request introduces a few adjustments to the security configuration and environment setup. The main changes are the addition of public access to authentication and API documentation endpoints, and switching the active profile to development mode.

Security configuration updates:

* Allowed public access to `/auth/**` and API documentation endpoints (`/swagger-ui/**`, `/v3/api-docs/**`) in the `SecurityConfig.java` file.

Environment setup:

* Changed the active Spring profile from `prod` to `dev` in `application.properties`, enabling development mode by default.